### PR TITLE
disable require once call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Zend Framework 1 for Composer
 =============================
 
-This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package. Some modifications were made for improved [Composer](http://getcomposer.org/) integration. This package can also be found at [Packagist](http://packagist.org/packages/zf1).
+This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package. Some modifications were made for improved [Composer](http://getcomposer.org/) integration. This package can also be found at [Packagist](http://packagist.org/packages/zf1s).
 
 ## Why?
 
@@ -10,13 +10,11 @@ This package is a part of the Zend Framework 1. Each component was separated and
 **Autoloading!** Explicit `require_once` calls in the source code has been commented out to rely on composer autoloading, this reduces the number of included files to a minimum.
 
 **Migration!** Zend Framework 2 has been around for a while now, and migrating all your projects takes a lot of time. Using these packages makes it easier to migrate each component separately. Also, some packages doesn't exist in zf2 (such as the zend-search-lucene), now you can continue using that package without requiring the entire framework.
-
-If you're using major parts of the framework, I would recommend checking out the [zendframework1 package](https://github.com/bombayworks/zendframework1), which contains the entire framework optimized for composer usage.
-
+ 
 ## How to use
 
-Add `"zf1/zend-application": "~1.12"` to the require section of your composer.json, include the composer autoloader and you're good to go.
+Add `"zf1s/zend-application": "~1.12"` to the require section of your composer.json, include the composer autoloader and you're good to go.
 
 ## Broken dependencies?
 
-Dependencies have been set automatically based on the [requirements from the zend framework manual](http://framework.zend.com/manual/1.12/en/requirements.introduction.html), if you find any broken dependencies please submit an issue.
+Dependencies have been set automatically based on the [requirements from the zend framework manual](http://framework.zend.com/manual/1.12/en/requirements.introduction.html), if you find any broken dependencies please submit a pull request.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "zf1/zend-application",
+	"name": "zf1s/zend-application",
 	"description": "Zend Framework 1 Application package",
 	"keywords": [
 		"framework",
@@ -11,8 +11,8 @@
 	"license": "BSD-3-Clause",
 	"require": {
 		"php": ">=5.2.11",
-		"zf1/zend-exception": "self.version",
-		"zf1/zend-controller": "self.version"
+		"zf1s/zend-exception": "^1.12",
+		"zf1s/zend-controller": "^1.12"
 	},
 	"autoload": {
 		"psr-0": {
@@ -20,6 +20,14 @@
 		}
 	},
 	"suggest": {
-		"zf1/zend-config": "Used in special situations or with special adapters"
+		"zf1s/zend-config": "Used in special situations or with special adapters"
+	},
+	"replace": {
+    	"zf1/zend-application": "^1.12"
+    },
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.x-dev"
+		}
 	}
 }

--- a/library/Zend/Application.php
+++ b/library/Zend/Application.php
@@ -70,15 +70,17 @@ class Zend_Application
      *
      * @param  string                   $environment
      * @param  string|array|Zend_Config $options String path to configuration file, or array/Zend_Config of configuration options
+     * @param bool $suppressNotFoundWarnings Should warnings be suppressed when a file is not found during autoloading?
      * @throws Zend_Application_Exception When invalid options are provided
      * @return void
      */
-    public function __construct($environment, $options = null)
+    public function __construct($environment, $options = null, $suppressNotFoundWarnings = null)
     {
         $this->_environment = (string) $environment;
 
         require_once 'Zend/Loader/Autoloader.php';
         $this->_autoloader = Zend_Loader_Autoloader::getInstance();
+        $this->_autoloader->suppressNotFoundWarnings($suppressNotFoundWarnings);
 
         if (null !== $options) {
             if (is_string($options)) {

--- a/library/Zend/Application.php
+++ b/library/Zend/Application.php
@@ -78,9 +78,10 @@ class Zend_Application
     {
         $this->_environment = (string) $environment;
 
-        require_once 'Zend/Loader/Autoloader.php';
-        $this->_autoloader = Zend_Loader_Autoloader::getInstance();
-        $this->_autoloader->suppressNotFoundWarnings($suppressNotFoundWarnings);
+        // see https://github.com/zf1/zend-application/pull/2 for discussion
+        // require_once 'Zend/Loader/Autoloader.php';
+        // $this->_autoloader = Zend_Loader_Autoloader::getInstance();
+        // $this->_autoloader->suppressNotFoundWarnings($suppressNotFoundWarnings);
 
         if (null !== $options) {
             if (is_string($options)) {


### PR DESCRIPTION
as zend classes are not in include path, any require once call will cause fatal error.

and enabling Zend autoloader causes it to load things from include path (which may be outside `vendor/` dir)
